### PR TITLE
Can't use memory graph with thread sanitizer

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -67,7 +67,7 @@ FLEX is an amazing debugging tool (not just for view debugging) and it's very ea
 
 ## Part 3: New Debugging Features in Xcode
 
-We looked at the memory graph debugger in Xcode to inspect memory usage and detect retain cycles.  You **can't** use this if you have the thread sanitizer activated
+We looked at the memory graph debugger in Xcode to inspect memory usage and detect retain cycles. Note that you can't activate the memory graph debugger if you have the thread sanitizer option turned on.
 
 ![Memory graph debugger button](assets/memory-graph.png)
 

--- a/README.markdown
+++ b/README.markdown
@@ -67,7 +67,7 @@ FLEX is an amazing debugging tool (not just for view debugging) and it's very ea
 
 ## Part 3: New Debugging Features in Xcode
 
-We looked at the memory graph debugger in Xcode to inspect memory usage and detect retain cycles.
+We looked at the memory graph debugger in Xcode to inspect memory usage and detect retain cycles.  You **can't** use this if you have the thread sanitizer activated
 
 ![Memory graph debugger button](assets/memory-graph.png)
 


### PR DESCRIPTION
Hey!
I was playing with this today and I realized that you can't use the memory graph if the thread sanitizer is activated

BTW really really nice workshop, I enjoyed a lot, thanks! :D